### PR TITLE
fix: filename cleanup

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -344,6 +344,15 @@ func (a *Asset) Install(id, binDir, optDir string) error {
 		dstFilename = strings.ReplaceAll(dstFilename, a.OS, "")
 		dstFilename = strings.ReplaceAll(dstFilename, a.Arch, "")
 
+		osData := osconfig.New(a.OS, a.Arch)
+		for _, osAlias := range osData.GetAliases() {
+			dstFilename = strings.ReplaceAll(dstFilename, osAlias, "")
+		}
+		for _, osArch := range osData.GetArchitectures() {
+			fmt.Println(osArch)
+			dstFilename = strings.ReplaceAll(dstFilename, osArch, "")
+		}
+
 		dstFilename = strings.ReplaceAll(dstFilename, fmt.Sprintf("v%s", a.Version), "")
 		dstFilename = strings.ReplaceAll(dstFilename, a.Version, "")
 

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -313,7 +313,7 @@ var versionReplace = regexp.MustCompile(`\d+\.\d+`)
 
 // Install installs the asset
 // TODO(ek): simplify this function
-func (a *Asset) Install(id, binDir, optDir string) error {
+func (a *Asset) Install(id, binDir, optDir string) error { //nolint:funlen
 	found := false
 
 	if err := os.MkdirAll(optDir, 0755); err != nil {

--- a/pkg/asset/asset_test.go
+++ b/pkg/asset/asset_test.go
@@ -474,6 +474,28 @@ func TestAssetInstall(t *testing.T) {
 				"test",
 			},
 		},
+		{
+			name:         "delta-aarch64-apple-darwin",
+			os:           "darwin",
+			arch:         "arm64",
+			version:      "1.0.0",
+			fileType:     Binary,
+			downloadFile: createFile(t, []byte{0xFE, 0xED, 0xFA, 0xCE}),
+			expectedFiles: []string{
+				"delta",
+			},
+		},
+		{
+			name:         "delta-x86_64-apple-darwin",
+			os:           "darwin",
+			arch:         "amd64",
+			version:      "1.0.0",
+			fileType:     Binary,
+			downloadFile: createFile(t, []byte{0xFE, 0xED, 0xFA, 0xCE}),
+			expectedFiles: []string{
+				"delta",
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -506,7 +528,7 @@ func TestAssetInstall(t *testing.T) {
 				destBinPath := filepath.Join(optDir, destBinaryName)
 
 				baseLinkName := filepath.Join(binDir, filepath.Base(fileName))
-				versionedLinkName := filepath.Join(binDir, fmt.Sprintf("%s@%s", filepath.Base(fileName), "1.0.0"))
+				versionedLinkName := filepath.Join(binDir, fmt.Sprintf("%s@%s", filepath.Base(fileName), version))
 
 				_, err = os.Stat(destBinPath)
 				assert.NoError(t, err)

--- a/pkg/osconfig/osconfig.go
+++ b/pkg/osconfig/osconfig.go
@@ -1,7 +1,5 @@
 package osconfig
 
-import "sort"
-
 const (
 	Windows = "windows"
 	Linux   = "linux"
@@ -13,7 +11,7 @@ const (
 )
 
 var (
-	AMD64Architectures = []string{"amd64", "x86_64", "64bit", "x64", "x86", "64-bit", "x86-64"}
+	AMD64Architectures = []string{"amd64", "x86_64", "x86-64", "64bit", "x64", "x86", "64-bit"}
 	ARM64Architectures = []string{"arm64", "aarch64", "armv8-a", "arm64-bit"}
 )
 
@@ -27,6 +25,10 @@ type OS struct {
 
 func (o *OS) GetOS() []string {
 	return append([]string{o.Name}, o.Aliases...)
+}
+
+func (o *OS) GetAliases() []string {
+	return o.Aliases
 }
 
 func (o *OS) GetArchitecture() string {
@@ -80,7 +82,7 @@ func New(os, arch string) *OS {
 		newOS.Aliases = []string{}
 		newOS.Extensions = []string{".AppImage"}
 	case Darwin:
-		newOS.Aliases = []string{"macos", "sonoma"}
+		newOS.Aliases = []string{"macos", "apple", "ventura", "sonoma", "sequoia"}
 		newOS.Architectures = append(newOS.Architectures, "universal")
 	}
 
@@ -92,7 +94,6 @@ func New(os, arch string) *OS {
 	}
 
 	newOS.Architectures = removeDuplicateStr(newOS.Architectures)
-	sort.Strings(newOS.Architectures)
 
 	return newOS
 }

--- a/pkg/osconfig/osconfig_test.go
+++ b/pkg/osconfig/osconfig_test.go
@@ -27,7 +27,7 @@ func TestOS_GetOS(t *testing.T) {
 		{
 			name:     "Darwin",
 			os:       osconfig.New(osconfig.Darwin, osconfig.AMD64),
-			expected: []string{"darwin", "macos", "sonoma"},
+			expected: []string{"darwin", "macos", "apple", "ventura", "sonoma", "sequoia"},
 		},
 	}
 


### PR DESCRIPTION
fixes a bug where trying to install asciinema 3.0.0 would result in a bad binary name on disk mainly for arm64.

```
dist install asciinema/asciinema@3.0.0-rc.3
```