### PR TITLE
fix: a few bugs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ and many others to pre-compile their software and put their binaries up on GitHu
 - Support multiple platforms and architectures
 - Support private repositories (this was a feature removed from homebrew)
 - Support checksum verifications (if they exist)
-- Support signatures verifications (if they exist) (**not implemented yet**)
+- Support signatures verifications (if they exist)
 - [Aliases](config/aliases.md) for easy access to binaries
 
 ## Examples

--- a/pkg/osconfig/osconfig.go
+++ b/pkg/osconfig/osconfig.go
@@ -82,7 +82,7 @@ func New(os, arch string) *OS {
 		newOS.Aliases = []string{}
 		newOS.Extensions = []string{".AppImage"}
 	case Darwin:
-		newOS.Aliases = []string{"macos", "apple", "ventura", "sonoma", "sequoia"}
+		newOS.Aliases = []string{"osx", "macos", "apple", "ventura", "sonoma", "sequoia"}
 		newOS.Architectures = append(newOS.Architectures, "universal")
 	}
 

--- a/pkg/osconfig/osconfig_test.go
+++ b/pkg/osconfig/osconfig_test.go
@@ -27,7 +27,7 @@ func TestOS_GetOS(t *testing.T) {
 		{
 			name:     "Darwin",
 			os:       osconfig.New(osconfig.Darwin, osconfig.AMD64),
-			expected: []string{"darwin", "macos", "apple", "ventura", "sonoma", "sequoia"},
+			expected: []string{"darwin", "osx", "macos", "apple", "ventura", "sonoma", "sequoia"},
 		},
 	}
 


### PR DESCRIPTION
- for now, allow the installer to proceed if no checksum or signature verifying tool can be found (future make these bypassed using env vars)
- add `osx` as an alias for MacOS, use case: https://github.com/duckdb/duckdb