### PR TITLE
fix(install): removing `function` keyword as `sh` does not support it

### DIFF
--- a/scripts/installer.tpl.sh
+++ b/scripts/installer.tpl.sh
@@ -24,7 +24,7 @@ case "$ARCH" in
 esac
 TAR_FILE="${FILE_BASENAME}-${VERSION}-${OS}-${ARCH}.tar.gz"
 
-function check_sha_version() {
+check_sha_version() {
     local currentver=$1
     local requiredver=$2
     if [ "$(printf '%s\n' "$requiredver" $1 | sort -V | head -n1)" = "$requiredver" ]; then


### PR DESCRIPTION
Was setting up my laptop today and noticed that the installer was broken on Linux :)

`sh`, which the install script defines in the shebang, does not support the `function` keyword, whereas `bash` and `zsh` do. Simply removing the keyword lets everything run as it normally would.