### PR TITLE
fix(install): allow alias to be used with version as argument

### DIFF
--- a/pkg/commands/install/install.go
+++ b/pkg/commands/install/install.go
@@ -32,10 +32,21 @@ func Execute(c *cli.Context) error { //nolint:gocyclo
 	inv := inventory.New(os.DirFS(cfg.BinPath), cfg.BinPath, cfg.GetOptPath(), cfg)
 
 	name := c.Args().First()
-	alias := cfg.GetAlias(c.Args().First())
+	nameParts := strings.Split(name, "@")
+	alias := cfg.GetAlias(nameParts[0])
 	if alias != nil {
 		name = alias.Name
-		_ = c.Set("version", alias.Version)
+		version := alias.Version
+		if len(nameParts) > 1 {
+			if version != "latest" {
+				log.Warn("version specified via cli and alias, ignoring alias version")
+			}
+			version = nameParts[1]
+		}
+
+		_ = c.Set("version", version)
+
+		name = fmt.Sprintf("%s@%s", name, version)
 	}
 
 	if name == "ekristen/distillery" {

--- a/pkg/commands/install/install.go
+++ b/pkg/commands/install/install.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ekristen/distillery/pkg/provider"
 )
 
-func Execute(c *cli.Context) error { //nolint:gocyclo
+func Execute(c *cli.Context) error { //nolint:gocyclo,funlen
 	start := time.Now().UTC()
 
 	cfg, err := config.New(c.String("config"))


### PR DESCRIPTION
This allows the use of `alias@version` whereas previously `alias` would always default to the `latest` or whatever version was specified in the configuration.

Now if you use `alias@version` the CLI will take precedence over the configuration, if there is a version that's not `latest` specified in the configuration file, the CLI wins.