### PR TITLE
feat: settings for better security controls

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -24,3 +24,28 @@ The configuration file is optional. If it is not found, the default configuratio
     ```toml
     default_provider = "github"
     ```
+
+## Aliases
+
+Aliases are useful shortcuts for repositories. See [Aliases](config/aliases.md) for more information.
+
+## Settings
+
+- `checksum-missing` (string): This is the behavior when a checksum is missing. The default is `warn`, valid values are `warn`, `error`, and `ignore`.
+- `signature-missing` (string): This is the behavior when a signature is missing. The default is `warn`, valid values are `warn`, `error`, and `ignore`.
+
+=== "YAML"
+
+    ```yaml
+    settings:
+      checksum-missing: warn
+      signature-missing: warn
+    ```
+
+=== "TOML"
+
+    ```toml
+    [settings]
+    checksum-missing = "warn"
+    signature-missing = "warn"
+    ```

--- a/pkg/commands/install/install.go
+++ b/pkg/commands/install/install.go
@@ -61,7 +61,7 @@ func Execute(c *cli.Context) error { //nolint:gocyclo,funlen
 			"version":              c.String("version"),
 			"github-token":         c.String("github-token"),
 			"gitlab-token":         c.String("gitlab-token"),
-			"no-signature-verify":  c.String("no-signature-verify"),
+			"no-signature-verify":  c.Bool("no-signature-verify"),
 			"no-checksum-verify":   c.Bool("no-checksum-verify"),
 			"no-score-check":       c.Bool("no-score-check"),
 			"include-pre-releases": c.Bool("include-pre-releases"),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,9 @@ type Config struct {
 	// Providers - allow for custom providers that uses one of the build in providers as a base. A good example of this
 	// is gitlab.alpinelinux.org, since gitlab is open source, you can use the gitlab provider as a base
 	Providers map[string]*Provider `yaml:"providers" toml:"providers"`
+
+	// Settings - settings to control the behavior of distillery
+	Settings *Settings `yaml:"settings" toml:"settings"`
 }
 
 func (c *Config) GetPath() string {
@@ -148,6 +151,11 @@ func New(path string) (*Config, error) {
 	if cfg.BinPath == "" {
 		cfg.BinPath = filepath.Join(cfg.Path, "bin")
 	}
+
+	if cfg.Settings == nil {
+		cfg.Settings = &Settings{}
+	}
+	cfg.Settings.Defaults()
 
 	return cfg, nil
 }

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -1,0 +1,20 @@
+package config
+
+// Settings - settings to control the behavior of distillery
+type Settings struct {
+	// ChecksumMissing - behavior when a checksum file is missing, this defaults to "warn", other options are "error" and "ignore"
+	ChecksumMissing string `yaml:"checksum-missing" toml:"checksum-missing"`
+	// ChecksumMismatch - behavior when a checksum file is missing, this defaults to "warn", other options are "error" and "ignore"
+	SignatureMissing string `yaml:"signature-missing" toml:"signature-missing"`
+}
+
+// Defaults - set the default values for the settings
+func (s *Settings) Defaults() {
+	if s.ChecksumMissing == "" {
+		s.ChecksumMissing = "warn"
+	}
+
+	if s.SignatureMissing == "" {
+		s.SignatureMissing = "warn"
+	}
+}


### PR DESCRIPTION
Implements the ability to prevent installs based on 2 new settings just introduced.

`checksum-missing` and `signature-missing` can be set to `error`, `ignore`, or `warn`, defaults to `warn`. If a checksum or signature is **missing** or cannot be determined install will happen by default.

However if checksums or signatures are found, they still have to match to install. There are tools such as https://github.com/FiloSottile/age that do not provide checksums or a way to verify the binary easily as they don't publish the keys, they are embedded in the readme file

This also fixes an issue where the `no-signature-verify` cli option wasn't being honored properly.

- Resolves #101 