### PR TITLE
feat: allow users to use env vars in config file

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,4 +48,27 @@ func TestConfigNewTOML(t *testing.T) {
 	}
 
 	assert.EqualValues(t, aliases, cfg.Aliases)
+}
+
+func TestProcessPath(t *testing.T) {
+	homePath, _ := os.UserHomeDir()
+	result := processPath("$HOME/.config/test")
+	assert.Equal(t, path.Join(homePath, ".config/test"), result)
+
+	result = processPath("/test/..")
+	assert.Equal(t, "/", result)
+
+	os.Setenv("TEST", "value")
+	result = processPath("/$TEST/path")
+	assert.Equal(t, "/value/path", result)
+
+	result = processPath("/$NAENV/test")
+	assert.Equal(t, "/test", result)
+
+	cwd, _ := os.Getwd()
+	result = processPath("test/path")
+	assert.Equal(t, path.Join(cwd, "test/path"), result)
+
+	result = processPath("/test//path")
+	assert.Equal(t, "/test/path", result)
 }


### PR DESCRIPTION
Allow users to use ENV vars in their config file (like $HOME).