### PR TITLE
fix: process path

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -85,28 +84,6 @@ func (c *Config) GetAlias(name string) *Alias {
 	return nil
 }
 
-// processPath - replaces env variables with their value and tries to get the shortest absolute path
-func processPath(path string) string {
-	if runtime.GOOS == "windows" {
-		homePath, err := os.UserHomeDir()
-		if err == nil {
-			path = strings.Replace(path, "$HOME", homePath, 1)
-		}
-	}
-	path = os.ExpandEnv(path)
-
-	if filepath.IsAbs(path) {
-		path = filepath.Clean(path)
-	} else {
-		absPath, err := filepath.Abs(path)
-		if err == nil {
-			path = filepath.Clean(absPath)
-		}
-	}
-
-	return filepath.ToSlash(path)
-}
-
 // MkdirAll - create all the directories
 func (c *Config) MkdirAll() error {
 	paths := []string{c.BinPath, c.GetOptPath(), c.GetCachePath(), c.GetMetadataPath(), c.GetDownloadsPath()}
@@ -181,4 +158,20 @@ func New(path string) (*Config, error) {
 	cfg.Settings.Defaults()
 
 	return cfg, nil
+}
+
+// processPath - replaces env variables with their value and tries to get the shortest absolute path
+func processPath(path string) string {
+	path = os.ExpandEnv(path)
+
+	if !filepath.IsAbs(path) {
+		absPath, err := filepath.Abs(path)
+		if err == nil {
+			path = filepath.Clean(absPath)
+		}
+	}
+
+	path = filepath.Clean(path)
+
+	return filepath.ToSlash(path)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -43,7 +43,6 @@ func TestConfigNewYAML(t *testing.T) {
 			assert.Equal(t, "3.29.3", cfg.GetAlias("aws-nuke").Version)
 		})
 	}
-
 }
 
 func TestProcessPath(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,45 +9,41 @@ import (
 )
 
 func TestConfigNewYAML(t *testing.T) {
-	cfg, err := New("testdata/base.yaml")
-	assert.NoError(t, err)
-
-	assert.Equal(t, "/home/test/.distillery", cfg.Path)
-	assert.Equal(t, "/home/test/.cache", cfg.CachePath)
-
-	aliases := &Aliases{
-		"dist": &Alias{
-			Name:    "ekristen/distillery",
-			Version: "latest",
-		},
-		"aws-nuke": &Alias{
-			Name:    "ekristen/aws-nuke",
-			Version: "3.29.3",
-		},
+	cases := []struct {
+		path string
+	}{
+		{"testdata/base.yaml"},
+		{"testdata/base.toml"},
 	}
 
-	assert.EqualValues(t, aliases, cfg.Aliases)
-}
+	for _, c := range cases {
+		t.Run(c.path, func(t *testing.T) {
+			cfg, err := New(c.path)
+			assert.NoError(t, err)
 
-func TestConfigNewTOML(t *testing.T) {
-	cfg, err := New("testdata/base.toml")
-	assert.NoError(t, err)
+			assert.Equal(t, "/home/test/.distillery", cfg.GetPath())
+			assert.Equal(t, "/home/test/.cache/distillery", cfg.GetCachePath())
+			assert.Equal(t, "/home/test/.distillery/opt", cfg.GetOptPath())
+			assert.Equal(t, "/home/test/.cache/distillery/metadata", cfg.GetMetadataPath())
+			assert.Equal(t, "/home/test/.cache/distillery/downloads", cfg.GetDownloadsPath())
 
-	assert.Equal(t, "/home/test/.distillery", cfg.Path)
-	assert.Equal(t, "/home/test/.cache", cfg.CachePath)
+			aliases := &Aliases{
+				"dist": &Alias{
+					Name:    "ekristen/distillery",
+					Version: "latest",
+				},
+				"aws-nuke": &Alias{
+					Name:    "ekristen/aws-nuke",
+					Version: "3.29.3",
+				},
+			}
 
-	aliases := &Aliases{
-		"dist": &Alias{
-			Name:    "ekristen/distillery",
-			Version: "latest",
-		},
-		"aws-nuke": &Alias{
-			Name:    "ekristen/aws-nuke",
-			Version: "3.29.3",
-		},
+			assert.EqualValues(t, aliases, cfg.Aliases)
+			assert.Equal(t, "latest", cfg.GetAlias("dist").Version)
+			assert.Equal(t, "3.29.3", cfg.GetAlias("aws-nuke").Version)
+		})
 	}
 
-	assert.EqualValues(t, aliases, cfg.Aliases)
 }
 
 func TestProcessPath(t *testing.T) {


### PR DESCRIPTION
Remove special windows handling, on windows users can use valid environment variables there. This also moves the function location in the file and expands test coverage.