### PR TITLE
fix(provider): skip checksum verification if invalid hash

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -39,6 +39,7 @@ Aliases are useful shortcuts for repositories. See [Aliases](config/aliases.md) 
 ## Settings
 
 - `checksum-missing` (string): This is the behavior when a checksum is missing. The default is `warn`, valid values are `warn`, `error`, and `ignore`.
+- `checksum-unknown` (string): This is the behavior when a checksum method is unknown. The default is `warn`, valid values are `warn`, `error`, and `ignore`.
 - `signature-missing` (string): This is the behavior when a signature is missing. The default is `warn`, valid values are `warn`, `error`, and `ignore`.
 
 === "YAML"
@@ -46,6 +47,7 @@ Aliases are useful shortcuts for repositories. See [Aliases](config/aliases.md) 
     ```yaml
     settings:
       checksum-missing: warn
+      checksum-unknown: warn
       signature-missing: warn
     ```
 
@@ -53,6 +55,7 @@ Aliases are useful shortcuts for repositories. See [Aliases](config/aliases.md) 
 
     ```toml
     [settings]
-    checksum-missing = "warn"
+    checksum-missing = "warn
+    checksum-unknown = "warn"
     signature-missing = "warn"
     ```

--- a/pkg/checksum/compare.go
+++ b/pkg/checksum/compare.go
@@ -16,6 +16,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var UnsupportedHashLengthError = fmt.Errorf("unsupported hash length")
+
 func ComputeFileHash(filePath string, hashFunc func() hash.Hash) (string, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -61,7 +63,7 @@ func DetermineHashFunc(checksumFilePath string) (func() hash.Hash, error) {
 	case 128:
 		return sha512.New, nil
 	default:
-		return nil, fmt.Errorf("unsupported hash length: %d", hashLength)
+		return nil, UnsupportedHashLengthError
 	}
 }
 

--- a/pkg/checksum/compare.go
+++ b/pkg/checksum/compare.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var UnsupportedHashLengthError = fmt.Errorf("unsupported hash length")
+var ErrUnsupportedHashLength = fmt.Errorf("unsupported hash length")
 
 func ComputeFileHash(filePath string, hashFunc func() hash.Hash) (string, error) {
 	file, err := os.Open(filePath)
@@ -63,7 +63,7 @@ func DetermineHashFunc(checksumFilePath string) (func() hash.Hash, error) {
 	case 128:
 		return sha512.New, nil
 	default:
-		return nil, UnsupportedHashLengthError
+		return nil, ErrUnsupportedHashLength
 	}
 }
 

--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -3,4 +3,8 @@ package common
 const (
 	Unknown = "unknown"
 	Latest  = "latest"
+
+	Warn   = "warn"
+	Error  = "error"
+	Ignore = "ignore"
 )

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -1,27 +1,30 @@
 package config
 
+import "github.com/ekristen/distillery/pkg/common"
+
 // Settings - settings to control the behavior of distillery
 type Settings struct {
 	// ChecksumMissing - behavior when a checksum file is missing, this defaults to "warn", other options are "error" and "ignore"
 	ChecksumMissing string `yaml:"checksum-missing" toml:"checksum-missing"`
+
 	// ChecksumMismatch - behavior when a checksum file is missing, this defaults to "warn", other options are "error" and "ignore"
 	SignatureMissing string `yaml:"signature-missing" toml:"signature-missing"`
 
-	/// ChecksumUnknown - behavior when a checksum method cannot be determined, this defaults to "warn", other options are "error" and "ignore"
+	// ChecksumUnknown - behavior when a checksum method cannot be determined, this defaults to "warn", other options are "error" and "ignore"
 	ChecksumUnknown string `yaml:"checksum-unknown" toml:"checksum-unknown"`
 }
 
 // Defaults - set the default values for the settings
 func (s *Settings) Defaults() {
 	if s.ChecksumMissing == "" {
-		s.ChecksumMissing = "warn"
+		s.ChecksumMissing = common.Warn
 	}
 
 	if s.SignatureMissing == "" {
-		s.SignatureMissing = "warn"
+		s.SignatureMissing = common.Warn
 	}
 
 	if s.ChecksumUnknown == "" {
-		s.ChecksumUnknown = "warn"
+		s.ChecksumUnknown = common.Warn
 	}
 }

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -6,6 +6,9 @@ type Settings struct {
 	ChecksumMissing string `yaml:"checksum-missing" toml:"checksum-missing"`
 	// ChecksumMismatch - behavior when a checksum file is missing, this defaults to "warn", other options are "error" and "ignore"
 	SignatureMissing string `yaml:"signature-missing" toml:"signature-missing"`
+
+	/// ChecksumUnknown - behavior when a checksum method cannot be determined, this defaults to "warn", other options are "error" and "ignore"
+	ChecksumUnknown string `yaml:"checksum-unknown" toml:"checksum-unknown"`
 }
 
 // Defaults - set the default values for the settings
@@ -16,5 +19,9 @@ func (s *Settings) Defaults() {
 
 	if s.SignatureMissing == "" {
 		s.SignatureMissing = "warn"
+	}
+
+	if s.ChecksumUnknown == "" {
+		s.ChecksumUnknown = "warn"
 	}
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -764,10 +764,17 @@ func (p *Provider) verifyChecksum() error {
 		p.Binary.GetFilePath(), p.Checksum.GetFilePath())
 	if err != nil {
 		if errors.Is(err, checksum.UnsupportedHashLengthError) {
-			log.Warn("skipping checksum verification (unsupported hash length)")
-			return nil
+			if p.Options.Config.Settings.ChecksumUnknown == "warn" {
+				log.Warn("skipping checksum verification (unsupported hash length)")
+				return nil
+			} else if p.Options.Config.Settings.ChecksumUnknown == "error" {
+				return err
+			} else if p.Options.Config.Settings.ChecksumUnknown == "ignore" {
+				return nil
+			}
+		} else {
+			return err
 		}
-		return err
 	}
 
 	logrus.Tracef("checksum match: %v", match)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -763,6 +763,10 @@ func (p *Provider) verifyChecksum() error {
 	match, err := checksum.CompareHashWithChecksumFile(p.Binary.GetName(),
 		p.Binary.GetFilePath(), p.Checksum.GetFilePath())
 	if err != nil {
+		if errors.Is(err, checksum.UnsupportedHashLengthError) {
+			log.Warn("skipping checksum verification (unsupported hash length)")
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ekristen/distillery/pkg/asset"
 	"github.com/ekristen/distillery/pkg/checksum"
+	"github.com/ekristen/distillery/pkg/common"
 	"github.com/ekristen/distillery/pkg/config"
 	"github.com/ekristen/distillery/pkg/cosign"
 	"github.com/ekristen/distillery/pkg/osconfig"
@@ -582,12 +583,12 @@ func (p *Provider) verifySignature() error {
 	}
 
 	if p.Signature == nil {
-		if p.Options.Config.Settings.SignatureMissing == "ignore" {
+		if p.Options.Config.Settings.SignatureMissing == common.Ignore {
 			return nil
-		} else if p.Options.Config.Settings.SignatureMissing == "warn" {
+		} else if p.Options.Config.Settings.SignatureMissing == common.Warn {
 			log.Warn("skipping signature verification (no signature)")
 			return nil
-		} else if p.Options.Config.Settings.SignatureMissing == "error" {
+		} else if p.Options.Config.Settings.SignatureMissing == common.Error {
 			return errors.New("signature verification failed (no signature)")
 		}
 	}
@@ -747,12 +748,12 @@ func (p *Provider) verifyChecksum() error {
 	}
 
 	if p.Checksum == nil {
-		if p.Options.Config.Settings.ChecksumMissing == "ignore" {
+		if p.Options.Config.Settings.ChecksumMissing == common.Ignore {
 			return nil
-		} else if p.Options.Config.Settings.ChecksumMissing == "warn" {
+		} else if p.Options.Config.Settings.ChecksumMissing == common.Warn {
 			log.Warn("skipping checksum verification (no checksum)")
 			return nil
-		} else if p.Options.Config.Settings.ChecksumMissing == "error" {
+		} else if p.Options.Config.Settings.ChecksumMissing == common.Error {
 			return errors.New("checksum verification failed (no checksum)")
 		}
 	}
@@ -763,13 +764,13 @@ func (p *Provider) verifyChecksum() error {
 	match, err := checksum.CompareHashWithChecksumFile(p.Binary.GetName(),
 		p.Binary.GetFilePath(), p.Checksum.GetFilePath())
 	if err != nil {
-		if errors.Is(err, checksum.UnsupportedHashLengthError) {
-			if p.Options.Config.Settings.ChecksumUnknown == "warn" {
+		if errors.Is(err, checksum.ErrUnsupportedHashLength) {
+			if p.Options.Config.Settings.ChecksumUnknown == common.Warn {
 				log.Warn("skipping checksum verification (unsupported hash length)")
 				return nil
-			} else if p.Options.Config.Settings.ChecksumUnknown == "error" {
+			} else if p.Options.Config.Settings.ChecksumUnknown == common.Error {
 				return err
-			} else if p.Options.Config.Settings.ChecksumUnknown == "ignore" {
+			} else if p.Options.Config.Settings.ChecksumUnknown == common.Ignore {
 				return nil
 			}
 		} else {


### PR DESCRIPTION
Basically if we cannot determine the length of a hash, we skip checksum verification instead of failing. 