### PR TITLE
feat(install): dist cache for github api

### DIFF
--- a/pkg/commands/install/install.go
+++ b/pkg/commands/install/install.go
@@ -61,6 +61,8 @@ func Execute(c *cli.Context) error { //nolint:gocyclo,funlen
 			"no-checksum-verify":   c.Bool("no-checksum-verify"),
 			"no-score-check":       c.Bool("no-score-check"),
 			"include-pre-releases": c.Bool("include-pre-releases"),
+			"use-dist-cache":       c.Bool("use-dist-cache"),
+			"dist-cache-url":       c.String("dist-cache-url"),
 		},
 	})
 	if err != nil {
@@ -244,6 +246,15 @@ func Flags() []cli.Flag {
 		&cli.BoolFlag{
 			Name:  "force",
 			Usage: "force the installation of the binary even if it is already installed",
+		},
+		&cli.BoolFlag{
+			Name:  "use-dist-cache",
+			Usage: "[EXPERIMENTAL] use the distillery pass-through cache for github to avoid authentication",
+		},
+		&cli.StringFlag{
+			Name:   "dist-cache-url",
+			Value:  "https://api.github.cache.dist.sh",
+			Hidden: true,
 		},
 	}
 }


### PR DESCRIPTION
## Overview

This is an experimental feature that will allow you to opt-in to using a pass through proxy to avoid rate limiting with no authentication to github api.

This is a free service I'm considering offering. Testing is needed.

## Important 

1. rate limiting is set to 100 req/min to prevent abuse (might need to change this)
2. if `--use-dist-cache` is enabled, no github auth will be used, so even if you have a github token defined it will be ignored, never sent.
3. the pass through cache uses github's etag and 304 to cache on the edge and re-check with github for changes.