### PR TITLE
fix: bug on decompression for unknown-types

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -552,6 +552,16 @@ func (a *Asset) doExtract(stream io.Reader) error {
 			return err
 		}
 	case archives.Decompressor:
+		// Skip decompression for Unknown-type assets to avoid false positives
+		// from content sniffing (e.g., brotli matching raw binaries).
+		// Legitimate compressed files have extensions and are classified as Archive.
+		if a.GetType() != Archive {
+			log.Debug().Str("app", a.GetName()).Msg("skipping decompression for non-archive asset, processing as direct file")
+			if err := a.processDirect(stream); err != nil {
+				return err
+			}
+			return nil
+		}
 		log.Debug().Str("app", a.GetName()).Msg("decompressing file")
 		rc, err := f.OpenReader(stream)
 		if err != nil {


### PR DESCRIPTION
Was trying to install https://github.com/bjarneo/cliamp and ran into a problem with a bad assumption on unknown types.