### PR TITLE
refactor: use segment-based filtering in cleanFilename

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
@@ -378,14 +379,84 @@ func (a *Asset) determineELF(path string) bool {
 	return bytes.Equal(magic, elfMagic)
 }
 
-var versionReplace = regexp.MustCompile(`\d+\.\d+`)
+var versionLikePattern = regexp.MustCompile(`\d+(\.\d+)+`)
+
+// buildDropSet returns a set of lowercased terms (OS, arch, version, aliases) that should be
+// removed from a filename during cleaning.
+func (a *Asset) buildDropSet() map[string]bool {
+	dropSet := map[string]bool{
+		strings.ToLower(a.OS):                          true,
+		strings.ToLower(a.Arch):                        true,
+		strings.ToLower(a.Version):                     true,
+		strings.ToLower(fmt.Sprintf("v%s", a.Version)): true,
+	}
+
+	osData := osconfig.New(a.OS, a.Arch)
+	for _, alias := range osData.GetAliases() {
+		dropSet[strings.ToLower(alias)] = true
+	}
+	for _, arch := range osData.GetArchitectures() {
+		dropSet[strings.ToLower(arch)] = true
+	}
+
+	return dropSet
+}
+
+// filterSegments splits a lowercased filename on delimiters, replacing multi-segment drop terms
+// and version-like patterns with placeholders first, then returns only the segments that don't
+// match any drop term.
+func filterSegments(name string, dropSet map[string]bool) []string {
+	// Collect multi-segment drop terms (those containing delimiters)
+	var multiSegTerms []string
+	for term := range dropSet {
+		if strings.ContainsAny(term, "-_.") {
+			multiSegTerms = append(multiSegTerms, term)
+		}
+	}
+	sort.Slice(multiSegTerms, func(i, j int) bool {
+		return len(multiSegTerms[i]) > len(multiSegTerms[j])
+	})
+
+	// Replace multi-segment terms with placeholders before splitting
+	placeholders := make(map[string]bool)
+	for i, term := range multiSegTerms {
+		ph := fmt.Sprintf("CLEANFNPH%d", i)
+		if strings.Contains(name, term) {
+			placeholders[ph] = true
+			name = strings.ReplaceAll(name, term, ph)
+		}
+	}
+
+	// Detect remaining version-like patterns (e.g., 10.12) and replace with placeholders
+	phIdx := len(multiSegTerms)
+	for _, match := range versionLikePattern.FindAllString(name, -1) {
+		ph := fmt.Sprintf("CLEANFNPH%d", phIdx)
+		placeholders[ph] = true
+		name = strings.Replace(name, match, ph, 1)
+		phIdx++
+	}
+
+	// Split on delimiters and filter
+	segments := strings.FieldsFunc(name, func(r rune) bool {
+		return r == '-' || r == '_' || r == '.'
+	})
+
+	var kept []string
+	for _, seg := range segments {
+		if placeholders[seg] || dropSet[seg] {
+			continue
+		}
+		kept = append(kept, seg)
+	}
+
+	return kept
+}
 
 // cleanFilename strips OS, arch, and version info from a filename to produce a clean binary name.
 func (a *Asset) cleanFilename(name string) string {
 	log.Trace().Str("app", a.GetName()).Msgf("pre-dstFilename: %s", name)
 
-	// Strip known archive/compression extensions (e.g. .gz, .tar.gz, .zip) so that
-	// files from compressed-only formats like .gz produce a clean binary name.
+	// Strip known archive/compression extensions (e.g. .gz, .tar.gz, .zip)
 	for {
 		ext := filepath.Ext(name)
 		if ext == "" || len(ext) > 5 || strings.Contains(ext, "_") {
@@ -398,31 +469,7 @@ func (a *Asset) cleanFilename(name string) string {
 		name = trimmed
 	}
 
-	// Strip the OS and Arch from the filename if it exists, this happens mostly when the binary is being
-	// uploaded directly instead of being encapsulated in a tarball or zip file
-	name = strings.ReplaceAll(name, a.OS, "")
-	name = strings.ReplaceAll(name, a.Arch, "")
-
-	osData := osconfig.New(a.OS, a.Arch)
-	for _, osAlias := range osData.GetAliases() {
-		name = strings.ReplaceAll(name, osAlias, "")
-	}
-	for _, osArch := range osData.GetArchitectures() {
-		name = strings.ReplaceAll(name, osArch, "")
-	}
-
-	name = strings.ReplaceAll(name, fmt.Sprintf("v%s", a.Version), "")
-	name = strings.ReplaceAll(name, a.Version, "")
-	name = versionReplace.ReplaceAllString(name, "")
-
-	if a.OS == osconfig.Windows || strings.HasSuffix(name, ".exe") {
-		name = strings.TrimSuffix(name, ".exe")
-	}
-
-	name = strings.TrimSpace(name)
-	name = strings.TrimRight(name, "-")
-	name = strings.TrimRight(name, "_")
-	name = strings.TrimRight(name, ".")
+	name = strings.Join(filterSegments(strings.ToLower(name), a.buildDropSet()), "-")
 
 	if a.OS == osconfig.Windows {
 		name = fmt.Sprintf("%s.exe", name)

--- a/pkg/asset/asset_test.go
+++ b/pkg/asset/asset_test.go
@@ -736,6 +736,46 @@ func TestCleanFilename(t *testing.T) {
 			input:    "direnv.linux-amd64",
 			expected: "direnv",
 		},
+		{
+			name:     "versioned-dot-delimited-binary",
+			assetOS:  "linux",
+			arch:     "amd64",
+			version:  "3.12.2",
+			input:    "sops-v3.12.2.linux.amd64",
+			expected: "sops",
+		},
+		{
+			name:     "residual-version-like-substring",
+			assetOS:  "darwin",
+			arch:     "amd64",
+			version:  "1.12.3",
+			input:    "test-1.12.3-darwin-10.12-amd64",
+			expected: "test",
+		},
+		{
+			name:     "underscore-delimited",
+			assetOS:  "linux",
+			arch:     "amd64",
+			version:  "1.5.0",
+			input:    "terraform_1.5.0_linux_amd64",
+			expected: "terraform",
+		},
+		{
+			name:     "preserve-non-known-segments",
+			assetOS:  "linux",
+			arch:     "amd64",
+			version:  "1.0.0",
+			input:    "fancy-tool-extra-linux-amd64",
+			expected: "fancy-tool-extra",
+		},
+		{
+			name:     "windows-exe",
+			assetOS:  "windows",
+			arch:     "amd64",
+			version:  "3.12.2",
+			input:    "sops-v3.12.2.amd64.exe",
+			expected: "sops.exe",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Replace strings.ReplaceAll approach with segment-based logic: split filename on delimiters, drop segments matching OS/arch/version/aliases, rejoin. Eliminates orphaned delimiter issues (e.g., sops- trailing dash).